### PR TITLE
[#4]test: delete 테스트 케이스 추가

### DIFF
--- a/ProjectManagerServer/Sources/App/Controllers/TaskController.swift
+++ b/ProjectManagerServer/Sources/App/Controllers/TaskController.swift
@@ -77,6 +77,12 @@ struct TaskController: RouteCollection {
     }
     
     func delete(request: Request) throws -> EventLoopFuture<HTTPStatus> {
+        request.headers.contentType = .json
+
+        guard request.headers.contentType == .json else {
+            throw TaskError.contentTypeIsNotJson
+        }
+        
         let foundTask = Task.find(request.parameters.get("id"), on: request.db).unwrap(or: Abort(.notFound))
         let deleteProcess = deleteTask(oldvalue: foundTask, request: request)
         

--- a/ProjectManagerServer/Tests/AppTests/TaskStub.swift
+++ b/ProjectManagerServer/Tests/AppTests/TaskStub.swift
@@ -11,6 +11,7 @@ import XCTVapor
 final class TaskStub {
     static let shared = TaskStub()
     
+    let expectedId = UUID(uuidString: "B60AC9A4-9D6B-489F-9373-F9A2412B818E")
     let expectedTitle = "James Good"
     let expectedContent = "king king"
     let expectedDate = Date()

--- a/ProjectManagerServer/Tests/AppTests/TestDELETE.swift
+++ b/ProjectManagerServer/Tests/AppTests/TestDELETE.swift
@@ -1,8 +1,8 @@
 @testable import App
 import XCTVapor
 
-/// Test DELTE Methods
-final class TestDELTE: XCTestCase {
+/// Test DELETE Methods
+final class TestDELETE: XCTestCase {
     var app: Application!
     
     override func setUpWithError() throws {
@@ -37,10 +37,6 @@ final class TestDELTE: XCTestCase {
     }
     
     func testFailToPostTasks() throws {
-        // given
-        let app = Application(.testing)
-        defer { app.shutdown() }
-        try configure(app)
         
         // when
         try app.test(.GET, "project/invalidURL", afterResponse: { response in

--- a/ProjectManagerServer/Tests/AppTests/TestDELTE.swift
+++ b/ProjectManagerServer/Tests/AppTests/TestDELTE.swift
@@ -1,0 +1,52 @@
+@testable import App
+import XCTVapor
+
+/// Test DELTE Methods
+final class TestDELTE: XCTestCase {
+    var app: Application!
+    
+    override func setUpWithError() throws {
+        
+        // given
+        app = try Application.testable()
+    }
+    
+    override func tearDownWithError() throws {
+        app.shutdown()
+    }
+    
+    func testDeleteTasks() throws {
+        
+        // given
+        let task = Task(
+            id: TaskStub.shared.expectedId,
+            title: TaskStub.shared.expectedTitle,
+            content: TaskStub.shared.expectedContent,
+            deadline_date: TaskStub.shared.expectedDate,
+            category: TaskStub.shared.expectedCategory
+        )
+        try task.save(on: app.db).wait()
+        
+        // when
+        try app.test(.DELETE, "project/task/B60AC9A4-9D6B-489F-9373-F9A2412B818E", beforeRequest: { request in
+            request.headers.contentType = .json
+        }, afterResponse: { response in
+            // then
+            XCTAssertEqual(response.status, .ok)
+        })
+    }
+    
+    func testFailToPostTasks() throws {
+        // given
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try configure(app)
+        
+        // when
+        try app.test(.GET, "project/invalidURL", afterResponse: { response in
+            
+            // then
+            XCTAssertEqual(response.status, .notFound)
+        })
+    }
+}


### PR DESCRIPTION
`delete`의 테스트 함수를 추가하였어요!
근데,
```swift
// TaskController.swift Line: 79
func delete(request: Request) throws -> EventLoopFuture<HTTPStatus> {
        request.headers.contentType = .json // <- 이 부분이 들어가도 될지 모르겠어요😢

        guard request.headers.contentType == .json else {
            throw TaskError.contentTypeIsNotJson
        }

        let foundTask = Task.find(request.parameters.get("id"), on: request.db).unwrap(or: Abort(.notFound))
        let deleteProcess = deleteTask(oldvalue: foundTask, request: request)

        return fetchSuccessfulStatus(event: deleteProcess)
    }
    
    private func deleteTask<T: Task>(oldvalue: EventLoopFuture<T>, request: Request) -> EventLoopFuture<Void> {
        
        return oldvalue.flatMap {
            $0.delete(on: request.db)
        }
    }
    
    private func fetchSuccessfulStatus(event: EventLoopFuture<Void>) -> EventLoopFuture<HTTPStatus> {
        let status: EventLoopFuture<HTTPStatus> = event.transform(to: .ok)
        
        return status
    }
}
```
위 코드의 표시부분을 보면, 매개변수인 `request`의 `headers.contentType`값이 자꾸 빈 값으로 들어가서
저기서 인위적으로 타입을 넣어주고 있어요
```swift
request.headers.contentType = .json
```
이런 식으로 작업을 해줘도 되는 걸까요..? 😭😭